### PR TITLE
brew-cask is no longer available since caskroom/homebrew-cask#15381.

### DIFF
--- a/lib/itamae/plugin/resource/cask.rb
+++ b/lib/itamae/plugin/resource/cask.rb
@@ -4,8 +4,6 @@ module Itamae
   module Plugin
     module Resource
       class Cask < Itamae::Resource::Base
-        BREW_CASK = 'brew-cask'
-
         define_attribute :action, default: :install
         define_attribute :target, type: String, default_name: true
         define_attribute :options, type: String, default: "--appdir=/Applications"
@@ -20,12 +18,12 @@ module Itamae
 
         def action_install(options)
           unless current.exist
-            run_command([BREW_CASK, "install", attributes.target])
+            run_command(["brew", "cask", "install", attributes.target])
           end
         end
 
         def action_alfred(options)
-          run_command([BREW_CASK, "alfred", attributes.target])
+          run_command(["brew", "cask", "alfred", attributes.target])
         end
 
         private
@@ -36,7 +34,7 @@ module Itamae
         end
 
         def ensure_brew_cask_availability
-          if run_command("which -s #{BREW_CASK}", error: false).exit_status != 0
+          if run_command("test -d $(brew --prefix)/Library/Taps/caskroom/homebrew-cask", error: false).exit_status != 0
             raise "`brew cask` command is not available. Please install brew cask."
           end
         end


### PR DESCRIPTION
Since https://github.com/caskroom/homebrew-cask/pull/15381 , `brew-cask` command is not available.
