### PR TITLE
Change module name to top-level

### DIFF
--- a/mrblib/itamae/plugin/resource/cask.rb
+++ b/mrblib/itamae/plugin/resource/cask.rb
@@ -1,4 +1,4 @@
-module MItamae
+module ::MItamae
   module Plugin
     module Resource
       class Cask < ::MItamae::Resource::Base

--- a/mrblib/itamae/plugin/resource_executor/cask.rb
+++ b/mrblib/itamae/plugin/resource_executor/cask.rb
@@ -1,4 +1,4 @@
-module MItamae
+module ::MItamae
   module Plugin
     module ResourceExecutor
       class Cask < ::MItamae::ResourceExecutor::Base


### PR DESCRIPTION
Before revision, These are defined as follows:

- `MItamae::Plugin::MItamae::Plugin::Resource::Cask`.
- `MItamae::Plugin::MItamae::Plugin::ResourceExecutor::Cask`.

test repository : https://github.com/gongo/try-bug-for-mitamae-plugin-resource-cask